### PR TITLE
Setup CI/CD for mobile app in /JoyboyCommunity

### DIFF
--- a/.github/workflows/joyboy-community.yml
+++ b/.github/workflows/joyboy-community.yml
@@ -1,0 +1,42 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+    paths:
+      - "JoyboyCommunity/**"
+
+jobs:
+  compile-with-lint-and-format:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: ["18.x", "20.x", "22.x"]
+
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v2
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      - name: Install Dependencies
+        run: yarn --cwd JoyboyCommunity install
+
+      - name: Dependencies Check
+        run: yarn --cwd JoyboyCommunity check
+
+      - name: Run Prettier Format Check
+        run: yarn --cwd JoyboyCommunity format:check
+
+      - name: Run ESLint Check
+        run: yarn --cwd JoyboyCommunity lint
+
+      - name: Run TypeScript Check
+        run: yarn --cwd JoyboyCommunity ts:check

--- a/JoyboyCommunity/README.md
+++ b/JoyboyCommunity/README.md
@@ -9,8 +9,8 @@ To test the project, run:
 
 ```bash
 cd JoyboyCommunity
-npm i
-npm start
+yarn install
+yarn start
 ```
 
 Select Expo web, Android or IOS. You can scan it with Expo GO on your phone.

--- a/JoyboyCommunity/package.json
+++ b/JoyboyCommunity/package.json
@@ -11,9 +11,11 @@
     "format": "prettier --write \"src/**/*.{ts,tsx}\"",
     "format:check": "prettier -c \"src/**/*.{ts,tsx}\"",
     "lint": "eslint \"src/**/*.{ts,tsx}\"",
+    "lint:strict": "eslint \"src/**/*.{ts,tsx}\" --max-warnings=0",
     "lint:fix": "yarn lint --fix",
     "ts:check": "tsc --noEmit",
-    "check": "yarn format:check && yarn lint && yarn ts:check"
+    "check:all": "yarn check && yarn format:check && yarn lint && yarn ts:check",
+    "check:all-strict": "yarn check && yarn format:check && yarn lint:strict && yarn ts:check"
   },
   "dependencies": {
     "@expo/metro-runtime": "~3.2.1",


### PR DESCRIPTION
### Added workflow `YAML` file for `JoyboyCommunity` app.

-  workflow only runs if code is pushed in `main` or PR is raised for `main`.
- workflow only runs if changes happen inside the `/JoyboyCommunity` folder where the `react native app` is located.
- workflow runs for multiple node versions `(subject to discussion if want to limit to specific version(s))`.
- Steps include:
  1. Installing dependencies.
  2. Dependencies check (`yarn check`)
      - current check lets warnings pass.
  3. Prettier Format check.
  4. ESLint Check
      - current check lets warnings pass. Can be updated to catch warnings as errors and fail script `(command has been added)`.
  5. Typescript Check
      - NOTE: Currently `tsonfig.json` doesn't essentially contain any `compilerOptions`.
        
        
### Updated `package.json` scripts

- `yarn check` has a different default purpose therefore changed custom script name to `yarn check:all`
- add `strict` checking for linting


### Updated `README`

- update docs accordingly as project is now using `yarn` instead of `npm`