### PR TITLE
ci: add typo detection tool

### DIFF
--- a/.github/workflows/config/typos.toml
+++ b/.github/workflows/config/typos.toml
@@ -1,0 +1,5 @@
+[default.extend-words]
+ba = "ba"
+
+[files]
+extend-exclude = ["/**/patches/**", "/**/assets/**"]

--- a/.github/workflows/typos.yml
+++ b/.github/workflows/typos.yml
@@ -1,0 +1,17 @@
+name: Typo Check
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  typos:
+    name: Spell Check with Typos
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+      - name: Use typos with config file
+        uses: crate-ci/typos@v1.21.0
+        with:
+          config: .github/workflows/config/typos.toml

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ sequenceDiagram
     Starknet Node->>Alice Account: SocialPay handler
     Alice Account->>STRK Token: transfer
     Starknet Node->>SocialPay relay: SocialPay transaction complete
-    SocialPay relay->>Bob: @bob you just recived 10 STRK from @alice
+    SocialPay relay->>Bob: @bob you just received 10 STRK from @alice
     SocialPay relay->>Alice: @alice transfer of 10 STRK to @bob is complete
     deactivate SocialPay relay
 ```

--- a/onchain/src/bip340.cairo
+++ b/onchain/src/bip340.cairo
@@ -357,7 +357,7 @@ mod tests {
 
     #[test]
     fn test_19() {
-        // signiture of message: joyboy, generated in broswer with nos2x extension
+        // signature of message: joyboy, generated in browser with nos2x extension
         let px: u256 = 0x98298b0b4a0d586771e7f84c742394b5013d37c16af0924bd7ee62ec6a517a5d;
         let rx: u256 = 0x3b7a0877cefa952d536fc167446a22f017922743db5cddd912b7890b7c5c34fe;
         let s: u256 = 0x2591fff0a4ac15d3ed5d3f767e686e771ec456af2fb53ffba163e509e16b0eba;

--- a/setuprelay.md
+++ b/setuprelay.md
@@ -14,7 +14,7 @@
 
 - ./scripts/run.sh
 
-# set up enviroment variable
+# set up environment variable
 
 - DATABASE_URL
 

--- a/website/src/components/DownloadSection.tsx
+++ b/website/src/components/DownloadSection.tsx
@@ -23,7 +23,7 @@ const DownloadSection: React.FC = () => {
           Download Joyboy
         </h3>
         <p className="text-sm desktop:text-[24px] desktop:leading-7 mb-6 tab:mb-[47px] desktop:w-[623px] w-[80%]">
-          Joyboy is available on Andriod, iOS, iPadOS and macOS. It's free and
+          Joyboy is available on Android, iOS, iPadOS and macOS. It's free and
           open source.
         </p>
         <div className="flex items-center gap-x-5">


### PR DESCRIPTION
Time spent on this PR: 1h

-  use [typos-action](https://github.com/marketplace/actions/typos-action) detect typos in github action
- fixed all checked typos && test github action
- Exclude some false postive word, please refer to the configuration file for details. like.
```
error: `ba` should be `by`, `be`
  --> ./onchain/src/bip340.cairo:68:5
   |
68 |     ba.append_word(rx.low.into(), 16);
   |     ^^
   |
error: `ba` should be `by`, `be`
  --> ./onchain/src/bip340.cairo:70:5
   |
70 |     ba.append_word(px.high.into(), 16);
```

**Result**
<img width="859" alt="image" src="https://github.com/keep-starknet-strange/joyboy/assets/165781272/cd6e908b-f357-4e79-b1e7-10247db57ec6">
