### PR TITLE
Refactor social account into public key component and social component

### DIFF
--- a/onchain/.tool-versions
+++ b/onchain/.tool-versions
@@ -1,0 +1,2 @@
+scarb 2.6.4
+starknet-foundry 0.24.0

--- a/onchain/src/social.cairo
+++ b/onchain/src/social.cairo
@@ -1,5 +1,7 @@
 pub mod account;
 pub mod bech32;
 pub mod profile;
+pub mod public_key_component;
 pub mod request;
+pub mod social_component;
 pub mod transfer;

--- a/onchain/src/social/public_key_component.cairo
+++ b/onchain/src/social/public_key_component.cairo
@@ -1,0 +1,34 @@
+#[starknet::interface]
+pub trait IPublicKey<TState> {
+    fn get_public_key(self: @TState) -> u256;
+}
+
+#[starknet::component]
+pub mod PublicKeyComponent {
+    #[storage]
+    struct Storage {
+        public_key: u256,
+    }
+
+    #[event]
+    #[derive(Drop, starknet::Event)]
+    pub enum Event {}
+
+    #[embeddable_as(PublicKeyImpl)]
+    pub impl PublicKey<
+        TContractState, +HasComponent<TContractState>, +Drop<TContractState>
+    > of super::IPublicKey<ComponentState<TContractState>> {
+        fn get_public_key(self: @ComponentState<TContractState>) -> u256 {
+            self.public_key.read()
+        }
+    }
+
+    #[generate_trait]
+    pub impl InternalImpl<
+        TContractState, +HasComponent<TContractState>, +Drop<TContractState>
+    > of InternalTrait<TContractState> {
+        fn initializer(ref self: ComponentState<TContractState>, public_key: u256) {
+            self.public_key.write(public_key);
+        }
+    }
+}

--- a/onchain/src/social/social_component.cairo
+++ b/onchain/src/social/social_component.cairo
@@ -1,0 +1,66 @@
+use super::request::SocialRequest;
+use super::transfer::Transfer;
+
+#[starknet::interface]
+pub trait ISocial<TState> {
+    fn handle_transfer(ref self: TState, request: SocialRequest<Transfer>);
+}
+
+#[starknet::component]
+pub mod SocialComponent {
+    use openzeppelin::token::erc20::interface::{ERC20ABIDispatcher, ERC20ABIDispatcherTrait};
+    use super::super::account::{ISocialAccountDispatcher, ISocialAccountDispatcherTrait};
+    use super::super::public_key_component::PublicKeyComponent::PublicKey;
+    use super::super::public_key_component::PublicKeyComponent;
+    use super::super::request::{SocialRequest, SocialRequestImpl};
+    use super::super::transfer::Transfer;
+
+    #[storage]
+    struct Storage {
+        transfers: LegacyMap<u256, bool>,
+    }
+
+    #[event]
+    #[derive(Drop, starknet::Event)]
+    pub enum Event {}
+
+    #[embeddable_as(SocialImpl)]
+    pub impl Social<
+        TContractState,
+        +HasComponent<TContractState>,
+        +Drop<TContractState>,
+        impl PublicKey: PublicKeyComponent::HasComponent<TContractState>
+    > of super::ISocial<ComponentState<TContractState>> {
+        fn handle_transfer(
+            ref self: ComponentState<TContractState>, request: SocialRequest<Transfer>
+        ) {
+            let public_key_component = get_dep_component!(@self, PublicKey);
+            assert!(
+                request.public_key == public_key_component.get_public_key(), "wrong public_key"
+            );
+
+            let erc20 = ERC20ABIDispatcher { contract_address: request.content.token_address };
+            assert!(erc20.symbol() == request.content.token, "wrong token symbol");
+
+            let recipient = ISocialAccountDispatcher {
+                contract_address: request.content.recipient_address
+            };
+
+            assert!(
+                recipient.get_public_key() == request.content.recipient.public_key,
+                "wrong public_key"
+            );
+
+            assert!(request.verify());
+
+            // check uniqueness
+
+            erc20.transfer(request.content.recipient_address, request.content.amount);
+        }
+    }
+
+    #[generate_trait]
+    pub impl InternalImpl<
+        TContractState, +HasComponent<TContractState>, +Drop<TContractState>
+    > of InternalTrait<TContractState> {}
+}


### PR DESCRIPTION
`SocialAccount` has been refactored using 2 components, `PublicKeyComponent` for `public_key` management and `SocialComponent` to handle social requests.

@maciejka Thanks for your guidance and review 👍 

Fixes #77