### PR TITLE
Refactor private key usage

### DIFF
--- a/JoyboyCommunity/src/hooks/useSendNote.tsx
+++ b/JoyboyCommunity/src/hooks/useSendNote.tsx
@@ -15,9 +15,7 @@ export const useSendNote = () => {
         throw new Error('Private key is required');
       }
 
-      const privateKeyString = Buffer.from(privateKey).toString('hex');
-
-      const signer = new NDKPrivateKeySigner(privateKeyString);
+      const signer = new NDKPrivateKeySigner(privateKey);
 
       const event = new NDKEvent(ndk);
       event.kind = NDKKind.Text;

--- a/JoyboyCommunity/src/screens/Auth/CreateAccount.tsx
+++ b/JoyboyCommunity/src/screens/Auth/CreateAccount.tsx
@@ -22,9 +22,9 @@ export const CreateAccount: React.FC<AuthCreateAccountScreenProps> = ({navigatio
       return;
     }
 
-    const {secretKeyHex, publicKey} = generateRandomKeypair();
+    const {privateKey, publicKey} = generateRandomKeypair();
 
-    await storePrivateKey(secretKeyHex, password);
+    await storePrivateKey(privateKey, password);
     await storePublicKey(publicKey);
 
     const biometySupported = canUseBiometricAuthentication();
@@ -44,7 +44,7 @@ export const CreateAccount: React.FC<AuthCreateAccountScreenProps> = ({navigatio
       ]);
     }
 
-    navigation.navigate('SaveKeys', {privateKey: secretKeyHex, publicKey});
+    navigation.navigate('SaveKeys', {privateKey, publicKey});
   };
 
   return (

--- a/JoyboyCommunity/src/screens/Auth/Login.tsx
+++ b/JoyboyCommunity/src/screens/Auth/Login.tsx
@@ -37,21 +37,22 @@ export const Login: React.FC<AuthLoginScreenProps> = ({navigation}) => {
       return;
     }
 
-    const secretKey = await retrieveAndDecryptPrivateKey(password);
-    if (!secretKey || secretKey.length !== 32) {
+    const privateKey = await retrieveAndDecryptPrivateKey(password);
+    if (!privateKey || privateKey.length !== 32) {
       alert('Invalid password');
       return;
     }
+    const privateKeyHex = privateKey.toString('hex');
 
     const storedPublicKey = await retrievePublicKey();
-    const publicKey = getPublicKeyFromSecret(secretKey);
+    const publicKey = getPublicKeyFromSecret(privateKeyHex);
 
     if (publicKey !== storedPublicKey) {
       alert('Invalid password');
       return;
     }
 
-    setAuth(publicKey, secretKey);
+    setAuth(publicKey, privateKeyHex);
   };
 
   return (

--- a/JoyboyCommunity/src/screens/Auth/SaveKeys.tsx
+++ b/JoyboyCommunity/src/screens/Auth/SaveKeys.tsx
@@ -23,7 +23,7 @@ export const SaveKeys: React.FC<AuthSaveKeysScreenProps> = ({route}) => {
   };
 
   const handleContinue = () => {
-    setAuth(publicKey, new Uint8Array(Buffer.from(privateKey, 'hex')));
+    setAuth(publicKey, privateKey);
   };
 
   return (

--- a/JoyboyCommunity/src/store/auth.ts
+++ b/JoyboyCommunity/src/store/auth.ts
@@ -4,11 +4,11 @@ import createBoundedUseStore from './createBoundedUseStore';
 
 type State = {
   publicKey: string | null;
-  privateKey: Uint8Array | null;
+  privateKey: string | null;
 };
 
 type Action = {
-  setAuth: (publicKey: string, privateKey: Uint8Array) => void;
+  setAuth: (publicKey: string, privateKey: string) => void;
 };
 
 export const authStore = createStore<State & Action>((set, get) => ({

--- a/JoyboyCommunity/src/utils/keypair.ts
+++ b/JoyboyCommunity/src/utils/keypair.ts
@@ -3,15 +3,14 @@ import {getRandomBytes} from 'expo-crypto';
 
 export const generateRandomKeypair = () => {
   try {
-    const secretKey = getRandomBytes(32);
-    const secretKeyHex = Buffer.from(secretKey).toString('hex');
+    const privateKey = getRandomBytes(32);
+    const privateKeyHex = Buffer.from(privateKey).toString('hex');
 
-    const publicKey = secp256k1.getPublicKey(secretKeyHex);
+    const publicKey = secp256k1.getPublicKey(privateKeyHex);
     const publicKeyHex = Buffer.from(publicKey).toString('hex');
 
     return {
-      secretKey,
-      secretKeyHex,
+      privateKey: privateKeyHex,
       publicKey: publicKeyHex,
     };
   } catch (error) {
@@ -20,12 +19,9 @@ export const generateRandomKeypair = () => {
   }
 };
 
-export const getPublicKeyFromSecret = (secretKey: Uint8Array | string) => {
+export const getPublicKeyFromSecret = (privateKey: string) => {
   try {
-    const secretKeyHex =
-      typeof secretKey === 'string' ? secretKey : Buffer.from(secretKey).toString('hex');
-
-    const publicKey = secp256k1.getPublicKey(secretKeyHex);
+    const publicKey = secp256k1.getPublicKey(privateKey);
     return Buffer.from(publicKey).toString('hex');
   } catch (error) {
     // We shouldn't throw the original error for security reasons

--- a/JoyboyCommunity/src/utils/storage.ts
+++ b/JoyboyCommunity/src/utils/storage.ts
@@ -39,9 +39,7 @@ export const storePrivateKey = async (privateKeyHex: string, password: string) =
   }
 };
 
-export const retrieveAndDecryptPrivateKey = async (
-  password: string,
-): Promise<false | Uint8Array> => {
+export const retrieveAndDecryptPrivateKey = async (password: string): Promise<false | Buffer> => {
   try {
     const encryptedPrivateKey = isSecureStoreAvailable
       ? await SecureStore.getItemAsync('encryptedPrivateKey')
@@ -60,10 +58,7 @@ export const retrieveAndDecryptPrivateKey = async (
       return false;
     }
 
-    const decryptedPrivateKey = pbkdf2Decrypt(parsedEncryptedPrivateKey, password);
-    const privateKey = new Uint8Array(decryptedPrivateKey);
-
-    return privateKey;
+    return pbkdf2Decrypt(parsedEncryptedPrivateKey, password);
   } catch (e) {
     // We shouldn't throw the original error for security reasons
     throw new Error('Error retrieving and decrypting private key');


### PR DESCRIPTION
`nostr-tools` were using Uint8Array for private keys, however NDK is using hex. So it will be better to always use hex private keys.
This PR replaces Uint8Array and Buffer private keys with hex private keys.