### PR TITLE
Fix: claim button and menu diviver theme colors

### DIFF
--- a/JoyboyCommunity/src/components/Menu/styles.ts
+++ b/JoyboyCommunity/src/components/Menu/styles.ts
@@ -28,7 +28,7 @@ export default ThemedStyleSheet((theme) => ({
     position: 'absolute',
     height: 'auto',
     gap: StyleSheet.hairlineWidth,
-    backgroundColor: theme.colors.background,
+    backgroundColor: theme.colors.divider,
     borderRadius: 16,
     overflow: 'hidden',
     shadowColor: theme.colors.shadow,

--- a/JoyboyCommunity/src/styles/Colors.tsx
+++ b/JoyboyCommunity/src/styles/Colors.tsx
@@ -81,7 +81,7 @@ export const DarkTheme = {
     textSecondary: '#FFFFFF',
     textLight: '#FFFFFF',
     textStrong: '#FFFFFF',
-    onPrimary: '#8F979E',
+    onPrimary: '#FFFFFF',
     onSecondary: '#FFFFFF',
 
     divider: '#1b1b18',


### PR DESCRIPTION
### Description 

- This PR fix bug of the [the beta testing ]( https://github.com/keep-starknet-strange/joyboy/issues/223 
)
- Issue #232 

- The Claim button and loading spinner on the dark theme do not match the appearance of other buttons and are hard to read.
- The menu divider should be lighter on both light and dark themes.

### Implementation 

- Updated theme colors for better readability and consistency.

### Screenshots

Claim dark issue
![claim dark](https://github.com/user-attachments/assets/b182d752-b3ad-4144-9cff-a24a64689b66)

menu divider too dark
![image](https://github.com/user-attachments/assets/36ab618a-fa83-409f-805e-770d769a81b9)


menu fix 
![image](https://github.com/user-attachments/assets/f662b6fa-4749-493e-961c-775d2c8f85b0)

claim button text on dark theme is white now, didn't have tips to show it but is fixed now! :D 
