### PR TITLE
Fix: show tip in user profile

### DIFF
--- a/JoyboyCommunity/src/context/TipModal.tsx
+++ b/JoyboyCommunity/src/context/TipModal.tsx
@@ -10,7 +10,6 @@ export type TipModalContextType = {
 
   showSuccess: (props: TipSuccessModalProps) => void;
   hideSuccess: () => void;
-  showTipProfile: (userPublicKeyToTip?: string) => void;
 };
 
 export const TipModalContext = createContext<TipModalContextType | null>(null);
@@ -19,16 +18,10 @@ export const TipModalProvider: React.FC<React.PropsWithChildren> = ({children}) 
   const tipModalRef = useRef<TipModal>(null);
 
   const [event, setEvent] = useState<NDKEvent | undefined>();
-  const [publicKeyToTip, setPublicKeyToTip] = useState<string | undefined>();
   const [successModal, setSuccessModal] = useState<TipSuccessModalProps | null>(null);
 
   const show = useCallback((event: NDKEvent) => {
     setEvent(event);
-    tipModalRef.current?.open();
-  }, []);
-
-  const showTipProfile = useCallback((userPublicKey?: string) => {
-    setPublicKeyToTip(userPublicKey);
     tipModalRef.current?.open();
   }, []);
 
@@ -46,8 +39,8 @@ export const TipModalProvider: React.FC<React.PropsWithChildren> = ({children}) 
   }, []);
 
   const context = useMemo(
-    () => ({show, hide, showSuccess, hideSuccess, showTipProfile}),
-    [show, hide, showSuccess, hideSuccess, showTipProfile],
+    () => ({show, hide, showSuccess, hideSuccess}),
+    [show, hide, showSuccess, hideSuccess],
   );
 
   return (
@@ -61,7 +54,6 @@ export const TipModalProvider: React.FC<React.PropsWithChildren> = ({children}) 
         showSuccess={showSuccess}
         hideSuccess={hideSuccess}
         ref={tipModalRef}
-        publicKeyToTip={publicKeyToTip}
       />
 
       {successModal && <TipSuccessModal {...successModal} />}

--- a/JoyboyCommunity/src/context/TipModal.tsx
+++ b/JoyboyCommunity/src/context/TipModal.tsx
@@ -10,6 +10,7 @@ export type TipModalContextType = {
 
   showSuccess: (props: TipSuccessModalProps) => void;
   hideSuccess: () => void;
+  showTipProfile: (userPublicKeyToTip?: string) => void;
 };
 
 export const TipModalContext = createContext<TipModalContextType | null>(null);
@@ -18,10 +19,16 @@ export const TipModalProvider: React.FC<React.PropsWithChildren> = ({children}) 
   const tipModalRef = useRef<TipModal>(null);
 
   const [event, setEvent] = useState<NDKEvent | undefined>();
+  const [publicKeyToTip, setPublicKeyToTip] = useState<string | undefined>();
   const [successModal, setSuccessModal] = useState<TipSuccessModalProps | null>(null);
 
   const show = useCallback((event: NDKEvent) => {
     setEvent(event);
+    tipModalRef.current?.open();
+  }, []);
+
+  const showTipProfile = useCallback((userPublicKey?: string) => {
+    setPublicKeyToTip(userPublicKey);
     tipModalRef.current?.open();
   }, []);
 
@@ -39,8 +46,8 @@ export const TipModalProvider: React.FC<React.PropsWithChildren> = ({children}) 
   }, []);
 
   const context = useMemo(
-    () => ({show, hide, showSuccess, hideSuccess}),
-    [show, hide, showSuccess, hideSuccess],
+    () => ({show, hide, showSuccess, hideSuccess, showTipProfile}),
+    [show, hide, showSuccess, hideSuccess, showTipProfile],
   );
 
   return (
@@ -54,6 +61,7 @@ export const TipModalProvider: React.FC<React.PropsWithChildren> = ({children}) 
         showSuccess={showSuccess}
         hideSuccess={hideSuccess}
         ref={tipModalRef}
+        publicKeyToTip={publicKeyToTip}
       />
 
       {successModal && <TipSuccessModal {...successModal} />}

--- a/JoyboyCommunity/src/modules/TipModal/index.tsx
+++ b/JoyboyCommunity/src/modules/TipModal/index.tsx
@@ -22,7 +22,6 @@ export type TipModal = Modalize;
 
 export type TipModalProps = {
   event?: NDKEvent;
-  publicKeyToTip?: string;
 
   show: (event: NDKEvent) => void;
   hide: () => void;
@@ -31,13 +30,13 @@ export type TipModalProps = {
 };
 
 export const TipModal = forwardRef<Modalize, TipModalProps>(
-  ({event, hide: hideTipModal, showSuccess, hideSuccess, publicKeyToTip}, ref) => {
+  ({event, hide: hideTipModal, showSuccess, hideSuccess}, ref) => {
     const styles = useStyles(stylesheet);
 
     const [token, setToken] = useState<TokenSymbol>(TokenSymbol.ETH);
     const [amount, setAmount] = useState<string>('');
 
-    const {data: profile} = useProfile({publicKey: event?.pubkey ?? publicKeyToTip});
+    const {data: profile} = useProfile({publicKey: event?.pubkey});
 
     const account = useAccount();
     const walletModal = useWalletModal();
@@ -69,7 +68,7 @@ export const TipModal = forwardRef<Modalize, TipModalProps>(
       const depositCallData = CallData.compile([
         amountUint256, // Amount
         TOKENS[token][CHAIN_ID].address, // Token address
-        uint256.bnToUint256(`0x${event?.pubkey ?? publicKeyToTip}`), // Recipient nostr pubkey
+        uint256.bnToUint256(`0x${event?.pubkey}`), // Recipient nostr pubkey
         DEFAULT_TIMELOCK, // timelock
       ]);
 
@@ -98,8 +97,7 @@ export const TipModal = forwardRef<Modalize, TipModalProps>(
             (profile?.nip05 && `@${profile.nip05}`) ??
             profile?.displayName ??
             profile?.name ??
-            event?.pubkey ??
-            publicKeyToTip,
+            event?.pubkey,
           hide: hideSuccess,
         });
       } else {
@@ -132,7 +130,7 @@ export const TipModal = forwardRef<Modalize, TipModalProps>(
                     numberOfLines={1}
                     ellipsizeMode="middle"
                   >
-                    {profile?.displayName ?? profile?.name ?? event?.pubkey ?? publicKeyToTip}
+                    {profile?.displayName ?? profile?.name ?? event?.pubkey}
                   </Text>
 
                   {profile?.nip05 && (
@@ -141,10 +139,6 @@ export const TipModal = forwardRef<Modalize, TipModalProps>(
                     </Text>
                   )}
                 </View>
-              </View>
-
-              <View style={styles.likes}>
-                <Text fontSize={11}>16 likes</Text>
               </View>
             </View>
 
@@ -205,8 +199,7 @@ export const TipModal = forwardRef<Modalize, TipModalProps>(
                 {(profile?.nip05 && `@${profile.nip05}`) ??
                   profile?.displayName ??
                   profile?.name ??
-                  event?.pubkey ??
-                  publicKeyToTip}
+                  event?.pubkey}
               </Text>
             </View>
           </View>

--- a/JoyboyCommunity/src/modules/TipModal/index.tsx
+++ b/JoyboyCommunity/src/modules/TipModal/index.tsx
@@ -22,6 +22,7 @@ export type TipModal = Modalize;
 
 export type TipModalProps = {
   event?: NDKEvent;
+  publicKeyToTip?: string;
 
   show: (event: NDKEvent) => void;
   hide: () => void;
@@ -30,13 +31,13 @@ export type TipModalProps = {
 };
 
 export const TipModal = forwardRef<Modalize, TipModalProps>(
-  ({event, hide: hideTipModal, showSuccess, hideSuccess}, ref) => {
+  ({event, hide: hideTipModal, showSuccess, hideSuccess, publicKeyToTip}, ref) => {
     const styles = useStyles(stylesheet);
 
     const [token, setToken] = useState<TokenSymbol>(TokenSymbol.ETH);
     const [amount, setAmount] = useState<string>('');
 
-    const {data: profile} = useProfile({publicKey: event?.pubkey});
+    const {data: profile} = useProfile({publicKey: event?.pubkey ?? publicKeyToTip});
 
     const account = useAccount();
     const walletModal = useWalletModal();
@@ -68,7 +69,7 @@ export const TipModal = forwardRef<Modalize, TipModalProps>(
       const depositCallData = CallData.compile([
         amountUint256, // Amount
         TOKENS[token][CHAIN_ID].address, // Token address
-        uint256.bnToUint256(`0x${event?.pubkey}`), // Recipient nostr pubkey
+        uint256.bnToUint256(`0x${event?.pubkey ?? publicKeyToTip}`), // Recipient nostr pubkey
         DEFAULT_TIMELOCK, // timelock
       ]);
 
@@ -97,7 +98,8 @@ export const TipModal = forwardRef<Modalize, TipModalProps>(
             (profile?.nip05 && `@${profile.nip05}`) ??
             profile?.displayName ??
             profile?.name ??
-            event?.pubkey,
+            event?.pubkey ??
+            publicKeyToTip,
           hide: hideSuccess,
         });
       } else {
@@ -130,7 +132,7 @@ export const TipModal = forwardRef<Modalize, TipModalProps>(
                     numberOfLines={1}
                     ellipsizeMode="middle"
                   >
-                    {profile?.displayName ?? profile?.name ?? event?.pubkey}
+                    {profile?.displayName ?? profile?.name ?? event?.pubkey ?? publicKeyToTip}
                   </Text>
 
                   {profile?.nip05 && (
@@ -203,7 +205,8 @@ export const TipModal = forwardRef<Modalize, TipModalProps>(
                 {(profile?.nip05 && `@${profile.nip05}`) ??
                   profile?.displayName ??
                   profile?.name ??
-                  event?.pubkey}
+                  event?.pubkey ??
+                  publicKeyToTip}
               </Text>
             </View>
           </View>

--- a/JoyboyCommunity/src/screens/Profile/Info/index.tsx
+++ b/JoyboyCommunity/src/screens/Profile/Info/index.tsx
@@ -31,7 +31,7 @@ export const ProfileInfo: React.FC<ProfileInfoProps> = ({publicKey: userPublicKe
   const userContacts = useContacts({authors: [userPublicKey]});
   const contacts = useContacts({authors: [publicKey]});
   const editContacts = useEditContacts();
-  const {showTipProfile} = useTipModal();
+  const {show: showTipModal} = useTipModal();
 
   const isSelf = publicKey === userPublicKey;
   const isConnected = contacts.data?.includes(userPublicKey);
@@ -121,7 +121,7 @@ export const ProfileInfo: React.FC<ProfileInfoProps> = ({publicKey: userPublicKe
                   label={profile?.username ? `Tip @${profile.username}` : 'Tip'}
                   icon="CoinIcon"
                   onPress={() => {
-                    showTipProfile(userPublicKey);
+                    showTipModal({pubkey: userPublicKey} as any);
                     setMenuOpen(false);
                   }}
                 />

--- a/JoyboyCommunity/src/screens/Profile/Info/index.tsx
+++ b/JoyboyCommunity/src/screens/Profile/Info/index.tsx
@@ -6,6 +6,7 @@ import {Pressable, View} from 'react-native';
 import {UserPlusIcon} from '../../../assets/icons';
 import {Button, IconButton, Menu, Text} from '../../../components';
 import {useContacts, useEditContacts, useProfile, useStyles, useTheme} from '../../../hooks';
+import {useTipModal} from '../../../hooks/modals';
 import {useAuth} from '../../../store/auth';
 import {ProfileScreenProps} from '../../../types';
 import {ProfileHead} from '../Head';
@@ -30,6 +31,7 @@ export const ProfileInfo: React.FC<ProfileInfoProps> = ({publicKey: userPublicKe
   const userContacts = useContacts({authors: [userPublicKey]});
   const contacts = useContacts({authors: [publicKey]});
   const editContacts = useEditContacts();
+  const {showTipProfile} = useTipModal();
 
   const isSelf = publicKey === userPublicKey;
   const isConnected = contacts.data?.includes(userPublicKey);
@@ -118,6 +120,10 @@ export const ProfileInfo: React.FC<ProfileInfoProps> = ({publicKey: userPublicKe
                 <Menu.Item
                   label={profile?.username ? `Tip @${profile.username}` : 'Tip'}
                   icon="CoinIcon"
+                  onPress={() => {
+                    showTipProfile(userPublicKey);
+                    setMenuOpen(false);
+                  }}
                 />
                 <Menu.Item
                   label={profile?.username ? `Share @${profile.username}` : 'Share'}


### PR DESCRIPTION
Fix:

Click on Tip in the User profile to open the Tip modal
Adding a show tip modal with only a user public key (no event in Profile/Info) to open the modal

![image](https://github.com/user-attachments/assets/dcb8fc33-50e6-48ca-9742-da9452764712)


![image](https://github.com/user-attachments/assets/c1accb2d-fe1c-4689-a329-4d2392c256bc)


Reported in #233
