### PR TITLE
#249: Long posts should have the see more feature

### DIFF
--- a/JoyboyCommunity/src/modules/Post/index.tsx
+++ b/JoyboyCommunity/src/modules/Post/index.tsx
@@ -45,6 +45,11 @@ export const Post: React.FC<PostProps> = ({asComment, event}) => {
   const queryClient = useQueryClient();
 
   const [menuOpen, setMenuOpen] = useState(false);
+  const [isContentExpanded, setIsContentExpanded] = useState(false);
+
+  const toggleExpandedContent = () => {
+    setIsContentExpanded((prev) => !prev);
+  };
 
   const scale = useSharedValue(1);
 
@@ -106,6 +111,9 @@ export const Post: React.FC<PostProps> = ({asComment, event}) => {
       },
     );
   };
+
+  const content = event?.content || '';
+  const truncatedContent = content.length > 200 ? `${content.slice(0, 200)}...` : content;
 
   return (
     <View style={styles.container}>
@@ -188,8 +196,14 @@ export const Post: React.FC<PostProps> = ({asComment, event}) => {
       <View style={styles.content}>
         <Pressable onPress={handleNavigateToPostDetails}>
           <Text color="textStrong" fontSize={13} lineHeight={20}>
-            {event?.content}
+            {isContentExpanded ? content : truncatedContent}
           </Text>
+
+          {content.length > 200 && (
+            <Pressable onPress={toggleExpandedContent}>
+              <Text style={styles.seeMore}>{isContentExpanded ? 'See less' : 'See more...'}</Text>
+            </Pressable>
+          )}
 
           {postSource && (
             <Image

--- a/JoyboyCommunity/src/modules/Post/styles.ts
+++ b/JoyboyCommunity/src/modules/Post/styles.ts
@@ -66,4 +66,9 @@ export default ThemedStyleSheet((theme) => ({
     alignItems: 'center',
     gap: Spacing.xxxsmall,
   },
+  seeMore: {
+    color: theme.colors.primary,
+    fontSize: 13,
+    marginTop: Spacing.xsmall,
+  },
 }));


### PR DESCRIPTION
### Description 

- This PR solves issue [#249  ]( https://github.com/keep-starknet-strange/joyboy/issues/249)

- Long posts take a lot of space on the screen, sometimes a lot of scrolling as well

### Implementation 

- Added a feature to expand or truncate post content.
- Created a state variable `isContentExpanded` and `toggleExpandedContent ` function to manage content expansion.
- Updated the UI to show  `"See more" / "See less"` on the same line if the content is too long.
- Added logic to handle truncation and toggling when content exceeds 200 characters.

### Screenshots
![image](https://github.com/user-attachments/assets/91734413-77f2-49c0-8c1c-bb650865df9d)
![image](https://github.com/user-attachments/assets/7f45f915-4190-4a8c-a836-1b5f17233267)

![image](https://github.com/user-attachments/assets/8cd79907-8335-42d2-86dc-0c5fb68a0d5e)

