### PR TITLE
#245: Add Network Check for Sepolia

### DIFF
--- a/JoyboyCommunity/src/app/App.tsx
+++ b/JoyboyCommunity/src/app/App.tsx
@@ -1,6 +1,6 @@
 import '@walletconnect/react-native-compat';
 
-import {starknetChainId, useNetwork} from '@starknet-react/core';
+import {starknetChainId, useAccount} from '@starknet-react/core';
 import * as Font from 'expo-font';
 import * as SplashScreen from 'expo-splash-screen';
 import {useCallback, useEffect, useState} from 'react';
@@ -22,10 +22,10 @@ export default function App() {
 
   const {showDialog, hideDialog} = useDialog();
 
-  const {chain} = useNetwork();
+  const account = useAccount();
 
   useEffect(() => {
-    const chainId = chain.id ? starknetChainId(chain.id) : undefined;
+    const chainId = account.chainId ? starknetChainId(account.chainId) : undefined;
 
     if (chainId) {
       if (chainId !== CHAIN_ID) {
@@ -39,7 +39,9 @@ export default function App() {
         hideDialog();
       }
     }
-  }, [chain.id]);
+
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [account.chainId]);
 
   useEffect(() => {
     (async () => {

--- a/JoyboyCommunity/src/app/App.tsx
+++ b/JoyboyCommunity/src/app/App.tsx
@@ -1,12 +1,14 @@
 import '@walletconnect/react-native-compat';
 
+import {starknetChainId, useNetwork} from '@starknet-react/core';
 import * as Font from 'expo-font';
 import * as SplashScreen from 'expo-splash-screen';
 import {useCallback, useEffect, useState} from 'react';
 import {View} from 'react-native';
 
+import {CHAIN_ID} from '../constants/env';
 import {useTips} from '../hooks';
-import {useToast} from '../hooks/modals';
+import {useDialog, useToast} from '../hooks/modals';
 import {Router} from './Router';
 
 SplashScreen.preventAutoHideAsync();
@@ -17,6 +19,27 @@ export default function App() {
 
   const tips = useTips();
   const {showToast} = useToast();
+
+  const {showDialog, hideDialog} = useDialog();
+
+  const {chain} = useNetwork();
+
+  useEffect(() => {
+    const chainId = chain.id ? starknetChainId(chain.id) : undefined;
+
+    if (chainId) {
+      if (chainId !== CHAIN_ID) {
+        showDialog({
+          title: 'Wrong Network',
+          description:
+            'Joyboy currently only supports the Starknet Sepolia network. Please switch to the Sepolia network to continue.',
+          buttons: [],
+        });
+      } else {
+        hideDialog();
+      }
+    }
+  }, [chain.id]);
 
   useEffect(() => {
     (async () => {

--- a/JoyboyCommunity/src/modules/TipModal/index.tsx
+++ b/JoyboyCommunity/src/modules/TipModal/index.tsx
@@ -1,12 +1,13 @@
 import {NDKEvent} from '@nostr-dev-kit/ndk';
+import {mainnet, sepolia} from '@starknet-react/chains';
 import {useAccount} from '@starknet-react/core';
-import {forwardRef, useState} from 'react';
+import {forwardRef, useEffect, useState} from 'react';
 import {View} from 'react-native';
 import {CallData, uint256} from 'starknet';
 
 import {Avatar, Button, Input, Modalize, Picker, Text} from '../../components';
 import {ESCROW_ADDRESSES} from '../../constants/contracts';
-import {CHAIN_ID} from '../../constants/env';
+import {CHAIN_ID, NETWORK_NAME} from '../../constants/env';
 import {DEFAULT_TIMELOCK, Entrypoint} from '../../constants/misc';
 import {TOKENS, TokenSymbol} from '../../constants/tokens';
 import {useProfile, useStyles, useWaitConnection} from '../../hooks';
@@ -44,6 +45,26 @@ export const TipModal = forwardRef<Modalize, TipModalProps>(
     const waitConnection = useWaitConnection();
 
     const {showDialog, hideDialog} = useDialog();
+
+    useEffect(() => {
+      const handleChainIdChange = () => {
+        const chainId = account.chainId;
+        const currentChainId = NETWORK_NAME === 'SN_MAIN' ? mainnet.id : sepolia.id;
+
+        if (chainId === currentChainId) {
+          hideDialog();
+        } else if (chainId) {
+          showDialog({
+            title: 'Wrong Network',
+            description:
+              'Joyboy currently only supports the Starknet Sepolia network. Please switch to the Sepolia network to continue.',
+            buttons: [],
+          });
+        }
+      };
+
+      handleChainIdChange();
+    }, [account.chainId, hideDialog, showDialog]);
 
     const isActive = !!amount && !!token;
 

--- a/JoyboyCommunity/src/modules/TipModal/index.tsx
+++ b/JoyboyCommunity/src/modules/TipModal/index.tsx
@@ -1,13 +1,12 @@
 import {NDKEvent} from '@nostr-dev-kit/ndk';
-import {mainnet, sepolia} from '@starknet-react/chains';
 import {useAccount} from '@starknet-react/core';
-import {forwardRef, useEffect, useState} from 'react';
+import {forwardRef, useState} from 'react';
 import {View} from 'react-native';
 import {CallData, uint256} from 'starknet';
 
 import {Avatar, Button, Input, Modalize, Picker, Text} from '../../components';
 import {ESCROW_ADDRESSES} from '../../constants/contracts';
-import {CHAIN_ID, NETWORK_NAME} from '../../constants/env';
+import {CHAIN_ID} from '../../constants/env';
 import {DEFAULT_TIMELOCK, Entrypoint} from '../../constants/misc';
 import {TOKENS, TokenSymbol} from '../../constants/tokens';
 import {useProfile, useStyles, useWaitConnection} from '../../hooks';
@@ -45,26 +44,6 @@ export const TipModal = forwardRef<Modalize, TipModalProps>(
     const waitConnection = useWaitConnection();
 
     const {showDialog, hideDialog} = useDialog();
-
-    useEffect(() => {
-      const handleChainIdChange = () => {
-        const chainId = account.chainId;
-        const currentChainId = NETWORK_NAME === 'SN_MAIN' ? mainnet.id : sepolia.id;
-
-        if (chainId === currentChainId) {
-          hideDialog();
-        } else if (chainId) {
-          showDialog({
-            title: 'Wrong Network',
-            description:
-              'Joyboy currently only supports the Starknet Sepolia network. Please switch to the Sepolia network to continue.',
-            buttons: [],
-          });
-        }
-      };
-
-      handleChainIdChange();
-    }, [account.chainId, hideDialog, showDialog]);
 
     const isActive = !!amount && !!token;
 


### PR DESCRIPTION
### Description 

- This PR solves issue [#245](https://github.com/keep-starknet-strange/joyboy/issues/245)

- There should be a check for connect account's chain id. If the chain is not Starknet Sepolia, app should show a uncloseable dialog. 

### Implementation 

- added a `useEffect` 
-Where handleChainIdChange`` checks if the user is on the correct network when the component mounts or the chain ID changes, showing or hiding the dialog accordingly.

### Screenshots

Using mainnet
![image](https://github.com/user-attachments/assets/fb985db3-d0f3-4ea1-94e4-cfb096fea4c3)
![image](https://github.com/user-attachments/assets/77e2e95f-eb17-4e02-9140-a496d8c1aea7)

Using sepolia
![image](https://github.com/user-attachments/assets/759c383f-989c-43ed-9dc5-b73c3fa4ad00)
![image](https://github.com/user-attachments/assets/afd0759f-2682-43de-b934-eb1043f76e88)