### PR TITLE
Fix: blank posts and comments

### DIFF
--- a/JoyboyCommunity/src/screens/CreatePost/index.tsx
+++ b/JoyboyCommunity/src/screens/CreatePost/index.tsx
@@ -40,7 +40,7 @@ export const CreatePost: React.FC<CreatePostScreenProps> = ({navigation}) => {
   };
 
   const handleSendNote = async () => {
-    if (!note || note?.length == 0) {
+    if (!note || note?.trim().length == 0) {
       showToast({type: 'error', title: 'Please write your note'});
       return;
     }

--- a/JoyboyCommunity/src/screens/PostDetail/index.tsx
+++ b/JoyboyCommunity/src/screens/PostDetail/index.tsx
@@ -23,7 +23,7 @@ export const PostDetail: React.FC<PostDetailScreenProps> = ({navigation, route})
   const {showToast} = useToast();
 
   const handleSendComment = async () => {
-    if (!comment || comment?.length == 0) {
+    if (!comment || comment?.trim().length == 0) {
       showToast({type: 'error', title: 'Please write your comment'});
       return;
     }


### PR DESCRIPTION
## Issue

This solves #286 

## Solution

The methods `handleSendNote` and `handleSendComment` were updated to trim the note/comment before checking its length.

